### PR TITLE
Add IndieAuth and microsub config

### DIFF
--- a/index.html
+++ b/index.html
@@ -16,8 +16,10 @@
 
 
 <!-- #indieauth stuff -->
-<link rel="pgpkey me" href="/AmyHurst-indieauth-Public.asc">
-
+<link rel="pgpkey me" href="/AmyHurst-indieauth-Public.asc" />
+<link rel="authorization_endpoint" href="https://indieauth.com/auth" />
+<link rel="token_endpoint" href="https://tokens.indieauth.com/token" />
+<link rel="microsub" href="https://aperture.maktro.net/microsub/2">
 
 <script src="/main.js"></script>
 


### PR DESCRIPTION
Add header link tags to specify indieauth.org for sign-in, tokens.indieauth.org for authorization token tracking, and Aperture for microsub reader endpoint.